### PR TITLE
Cambio Nombre Proyecto en Archivos Config Boostrap

### DIFF
--- a/bootstrap/cache/config.php
+++ b/bootstrap/cache/config.php
@@ -184,7 +184,7 @@
       'file' => 
       array (
         'driver' => 'file',
-        'path' => 'C:\\laragon\\www\\ugcore1\\storage\\framework/cache/data',
+        'path' => 'C:\\laragon\\www\\ugcore\\storage\\framework/cache/data',
       ),
       'memcached' => 
       array (
@@ -491,10 +491,10 @@
     'orientation' => 'portrait',
     'defines' => 
     array (
-      'DOMPDF_FONT_DIR' => 'C:\\laragon\\www\\ugcore1\\storage\\fonts/',
-      'DOMPDF_FONT_CACHE' => 'C:\\laragon\\www\\ugcore1\\storage\\fonts/',
+      'DOMPDF_FONT_DIR' => 'C:\\laragon\\www\\ugcore\\storage\\fonts/',
+      'DOMPDF_FONT_CACHE' => 'C:\\laragon\\www\\ugcore\\storage\\fonts/',
       'DOMPDF_TEMP_DIR' => 'C:\\Users\\DELL\\AppData\\Local\\Temp',
-      'DOMPDF_CHROOT' => 'C:\\laragon\\www\\ugcore1',
+      'DOMPDF_CHROOT' => 'C:\\laragon\\www\\ugcore',
       'DOMPDF_UNICODE_ENABLED' => true,
       'DOMPDF_ENABLE_FONT_SUBSETTING' => false,
       'DOMPDF_PDF_BACKEND' => 'CPDF',
@@ -519,12 +519,12 @@
       'local' => 
       array (
         'driver' => 'local',
-        'root' => 'C:\\laragon\\www\\ugcore1\\storage\\app',
+        'root' => 'C:\\laragon\\www\\ugcore\\storage\\app',
       ),
       'public' => 
       array (
         'driver' => 'local',
-        'root' => 'C:\\laragon\\www\\ugcore1\\storage\\app/public',
+        'root' => 'C:\\laragon\\www\\ugcore\\storage\\app/public',
         'url' => 'http://siug.ug.edu.ec/storage',
         'visibility' => 'public',
       ),
@@ -596,7 +596,7 @@
       'theme' => 'default',
       'paths' => 
       array (
-        0 => 'C:\\laragon\\www\\ugcore1\\resources\\views/vendor/mail',
+        0 => 'C:\\laragon\\www\\ugcore\\resources\\views/vendor/mail',
       ),
     ),
     'stream' => 
@@ -699,7 +699,7 @@
     'lifetime' => 30,
     'expire_on_close' => true,
     'encrypt' => false,
-    'files' => 'C:\\laragon\\www\\ugcore1\\storage\\framework/sessions',
+    'files' => 'C:\\laragon\\www\\ugcore\\storage\\framework/sessions',
     'connection' => NULL,
     'table' => 'sessions',
     'store' => NULL,
@@ -730,8 +730,8 @@
   array (
     'paths' => 
     array (
-      0 => 'C:\\laragon\\www\\ugcore1\\resources\\views',
+      0 => 'C:\\laragon\\www\\ugcore\\resources\\views',
     ),
-    'compiled' => 'C:\\laragon\\www\\ugcore1\\storage\\framework\\views',
+    'compiled' => 'C:\\laragon\\www\\ugcore\\storage\\framework\\views',
   ),
 );

--- a/storage/framework/sessions/Yhjhb10qqFA9xbkjIa0H6YLx3pSZdmJWJpPKgsU3
+++ b/storage/framework/sessions/Yhjhb10qqFA9xbkjIa0H6YLx3pSZdmJWJpPKgsU3
@@ -1,1 +1,1 @@
-a:4:{s:6:"_flash";a:2:{s:3:"old";a:0:{}s:3:"new";a:0:{}}s:6:"_token";s:40:"IYghfc7lANjtQMg4iJN6tpsdtDveIhioxNadVVWY";s:9:"_previous";a:1:{s:3:"url";s:46:"http://ugcore1.dev/titulacion/complexivo/notas";}s:50:"login_web_59ba36addc2b2f9401580f014c7f58ea4e30989d";i:2443;}
+a:4:{s:6:"_flash";a:2:{s:3:"old";a:0:{}s:3:"new";a:0:{}}s:6:"_token";s:40:"IYghfc7lANjtQMg4iJN6tpsdtDveIhioxNadVVWY";s:9:"_previous";a:1:{s:3:"url";s:46:"http://ugcore.dev/titulacion/complexivo/notas";}s:50:"login_web_59ba36addc2b2f9401580f014c7f58ea4e30989d";i:2443;}


### PR DESCRIPTION
Se modifica el nombre del proyecto base **UGCORE1** al nombre **UGCORE** a nivel de los archivos de configuración de boostrap para normalizar el estándar del nombrado del proyecto.